### PR TITLE
Update tests to close() formally

### DIFF
--- a/src/test/scala/org/clulab/geonorm/GeoNormSpec.scala
+++ b/src/test/scala/org/clulab/geonorm/GeoNormSpec.scala
@@ -1,11 +1,19 @@
 package org.clulab.geonorm
 
 import java.nio.file.{Files, Paths}
-
 import org.apache.commons.io.FileUtils
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
-class GeoNormSpec extends WordSpec with Matchers {
+class GeoNormSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+  val indexTempDir = Files.createTempDirectory("geonames")
+  var geoNamesIndexOpt: Option[GeoNamesIndex] = None
+
+  override def afterAll(): Unit = {
+    // The index should be closed after all tests have completed.
+    geoNamesIndexOpt.map(_.close())
+    // This directory can be deleted only after all indexes have been closed.
+    FileUtils.deleteDirectory(indexTempDir.toFile)
+  }
 
   "an extractor" when {
     "loaded from the default location" should {
@@ -31,23 +39,18 @@ class GeoNormSpec extends WordSpec with Matchers {
   "a normalizer" when {
     "loaded from MC.txt with the default linear model" should {
       val mcTxt = Paths.get("src/test/resources/geonames/MC.txt")
-      val indexTempDir = Files.createTempDirectory("geonames")
-      try {
-        val index = GeoNamesIndex.fromGeoNamesTxt(indexTempDir, mcTxt)
-        val normalizer = new GeoLocationNormalizer(index)
-        "select the correct exact-match Monaco" in {
-          assert(normalizer("Monaco").head._1.id === "2993457")
-        }
-        "rank Monte-Carlo first when searching for Carlo" in {
-          assert(normalizer("Carlo").head._1.id === "2992741")
-        }
-        "fail to find any match for Zxxy" in {
-          assert(normalizer("Zxxy") === Array.empty)
-        }
-      } finally {
-        FileUtils.deleteDirectory(indexTempDir.toFile)
+      geoNamesIndexOpt = Some(GeoNamesIndex.fromGeoNamesTxt(indexTempDir, mcTxt))
+      val index = geoNamesIndexOpt.get
+      val normalizer = new GeoLocationNormalizer(index)
+      "select the correct exact-match Monaco" in {
+        assert(normalizer("Monaco").head._1.id === "2993457")
+      }
+      "rank Monte-Carlo first when searching for Carlo" in {
+        assert(normalizer("Carlo").head._1.id === "2992741")
+      }
+      "fail to find any match for Zxxy" in {
+        assert(normalizer("Zxxy") === Array.empty)
       }
     }
-
   }
 }


### PR DESCRIPTION
These tests always failed for Windows and might fail or just not work properly for Linux if timing is unlucky.  For example, finally can be executed before the asynchronous tests run and indexes are not closed so that the directory cannot be deleted.  This *seems* to work now, but there might be better ways to go about it.